### PR TITLE
Found and fixed an error when porting this repo to actual website.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   Due to a problem with the hills server (where we host the coders club website), we require a index.html file so we do not generate a '500 internal server error.'
   -->
     <script>
-      window.location.href = '../templates/index.php';
+      window.location.href = 'templates/index.php';
     </script>
     
 </html>

--- a/partials/upsydownsy.php
+++ b/partials/upsydownsy.php
@@ -1,6 +1,6 @@
 <!-- Begin upsydownsy.php -->
 <nav><ul>
-  <li><a href='index.html' >Upsidasy</a></li>
-  <li><a href='index.html#contact' >Downsidasy</a></li>
+  <li><a href='index.php'>Upsidasy</a></li>
+  <li><a href='#contact'>Downsidasy</a></li>
 </nav>
 <!-- End upsydownsy.php -->


### PR DESCRIPTION
the preceding '/' was directing hills to this url: 'hills.ccsf.edu/templates/index.php' instead of this correct url: 'hills.ccsf.edu/~coders/templates/index.php'

Whats doubly nice is that this change does not affect the Vagrant environment, so no additional changes need to be made to that, woo!
